### PR TITLE
Fix bug with SegmentSet dissapearing from scene when dynamically adding segments.

### DIFF
--- a/away3d/entities/SegmentSet.hx
+++ b/away3d/entities/SegmentSet.hx
@@ -98,6 +98,7 @@ class SegmentSet extends Entity implements IRenderable {
         subSet.numVertices = Std.int(subSet.vertices.length / 11);
         subSet.numIndices = subSet.indices.length;
         subSet.lineCount++;
+		subSet.indexBufferDirty=true;
 
         var segRef:SegRef = new SegRef();
         segRef.index = index;


### PR DESCRIPTION
invalidate index buffer when calling addSegment to prevent the entire SegmentSet from dissapearing