### PR TITLE
shared context enhancements

### DIFF
--- a/away3d/containers/View3D.hx
+++ b/away3d/containers/View3D.hx
@@ -97,6 +97,7 @@ class View3D extends Sprite
     var _profile:String;
     var _layeredView:Bool = false;
     var _callbackMethod:Event -> Void;
+	var _contextIndex:Int = -1;
     
     // private function viewSource(e:ContextMenuEvent):Void
     // {
@@ -154,9 +155,9 @@ class View3D extends Sprite
     //  //contextMenu = _ViewContextMenu;
     // }
     
-    public function new(scene:Scene3D = null, camera:Camera3D = null, renderer:RendererBase = null, forceSoftware:Bool = false, profile:String = "baseline")
+    public function new(scene:Scene3D = null, camera:Camera3D = null, renderer:RendererBase = null, forceSoftware:Bool = false, profile:String = "baseline", contextIndex:Int=-1)
     {
-        _width = 0;
+		_width = 0;
         _height = 0;
         _localPos = new Point();
         _globalPos = new Point();
@@ -185,7 +186,8 @@ class View3D extends Sprite
         _renderer = renderer!=null ? renderer : new DefaultRenderer();
         _depthRenderer = new DepthRenderer();
         _forceSoftware = forceSoftware;
-        
+        _contextIndex = contextIndex;
+		
         // todo: entity collector should be defined by renderer
         _entityCollector = _renderer.createEntityCollector();
         _entityCollector.camera = _camera;
@@ -885,7 +887,7 @@ class View3D extends Sprite
             }
         }
         
-        if (!_shareContext) {
+		if (!_shareContext) {
             stage3DProxy.present();
             
             // fire collected mouse events
@@ -1119,7 +1121,8 @@ class View3D extends Sprite
         _addedToStage = true;
         
         if (_stage3DProxy==null) {
-            _stage3DProxy = Stage3DManager.getInstance(stage).getFreeStage3DProxy(_forceSoftware, _profile);
+            if (_contextIndex == -1) _stage3DProxy = Stage3DManager.getInstance(stage).getFreeStage3DProxy(_forceSoftware, _profile);
+			else _stage3DProxy = Stage3DManager.getInstance(stage).getStage3DProxy(_contextIndex, _forceSoftware, _profile);
             _stage3DProxy.addEventListener(Stage3DEvent.VIEWPORT_UPDATED, onViewportUpdated);
             if (_callbackMethod!=null) {
                 _stage3DProxy.setRenderCallback(_callbackMethod);

--- a/away3d/core/managers/Stage3DProxy.hx
+++ b/away3d/core/managers/Stage3DProxy.hx
@@ -126,13 +126,17 @@ class Stage3DProxy extends EventDispatcher {
 
         super();
 
-        // whatever happens, be sure this has highest priority
-        _stage3D.addEventListener(Event.CONTEXT3D_CREATE, onContext3DUpdate, false, 1000, false);
-
         this.forceSoftware = forceSoftware;
-        this._profile = profile;
-
-        requestContext(forceSoftware, _profile);
+		this._profile = profile;
+		
+        // whatever happens, be sure this has highest priority
+		if (_stage3D.context3D == null){
+			_stage3D.addEventListener(Event.CONTEXT3D_CREATE, onContext3DUpdate, false, 1000, false);
+			requestContext(forceSoftware, _profile);
+		}
+		else {
+			onContext3DUpdate(null);
+		}
     }
 
     private var forceSoftware:Bool ;

--- a/away3d/core/managers/Stage3DProxy.hx
+++ b/away3d/core/managers/Stage3DProxy.hx
@@ -543,7 +543,7 @@ class Stage3DProxy extends EventDispatcher {
         // ugly stuff for backward compatibility
         var renderMode:Context3DRenderMode = (forceSoftware) ? Context3DRenderMode.SOFTWARE : Context3DRenderMode.AUTO;
         #if flash
-            _stage3D.requestContext3D(renderMode);
+            _stage3D.requestContext3D(cast renderMode);
         #else
             _stage3D.requestContext3D(Std.string(renderMode));
         #end


### PR DESCRIPTION
These changes are necessary to enable the use of a context3D which is initialized before a View3D instance is created. This is useful when multiple Starling and Away3D instances are sharing the same context3D and rendering orders are being managed outside of Away3D. An example can be viewed at: http://blog.peteshand.net/haxe-away3d-starling-integration-sneak-peek/