### PR TITLE
BitmapFont Textfield support

### DIFF
--- a/away3d/textfield/BitmapChar.hx
+++ b/away3d/textfield/BitmapChar.hx
@@ -1,0 +1,91 @@
+// =================================================================================================
+//
+//	Starling Framework
+//	Copyright 2011-2014 Gamua. All Rights Reserved.
+//
+//	This program is free software. You can redistribute and/or modify it
+//	in accordance with the terms of the accompanying license agreement.
+//
+// =================================================================================================
+
+package away3d.textfield;
+
+
+/** A BitmapChar contains the information about one char of a bitmap font.  
+ *  <em>You don't have to use this class directly in most cases. 
+ *  The TextField class contains methods that handle bitmap fonts for you.</em>    
+ */ 
+class BitmapChar
+{
+	private var mCharID:Int;
+	private var mXOffset:Float;
+	private var mYOffset:Float;
+	private var mXAdvance:Float;
+	private var mKernings:Map<Int, Float>;
+
+	private var mX:Float;
+	private var mY:Float;
+	private var mWidth:Float;
+	private var mHeight:Float;
+
+	/** Creates a char with a texture and its properties. */
+	public function new(id:Int, x:Float, y:Float, width:Float, height:Float, xOffset:Float, yOffset:Float, xAdvance:Float)
+	{
+		mCharID = id;
+		mXOffset = xOffset;
+		mYOffset = yOffset;
+		mXAdvance = xAdvance;
+		mKernings = null;
+		mX = x;
+		mY = y;
+		mWidth = width;
+		mHeight = height;
+	}
+	
+	/** Adds kerning information relative to a specific other character ID. */
+	public function addKerning(charID:Int, amount:Float):Void
+	{
+		if (mKernings == null)
+			mKernings = new Map<Int, Float>();
+		
+		mKernings[charID] = amount;
+	}
+	
+	/** Retrieve kerning information relative to the given character ID. */
+	public function getKerning(charID:Int):Float
+	{
+		if (mKernings == null || mKernings.get(charID) == null) return 0.0;
+		else return mKernings[charID];
+	}
+
+	
+	/** The unicode ID of the char. */
+	public var charID(get, null):Int;
+	public function get_charID():Int { return mCharID; }
+	
+	/** The number of points to move the char in x direction on character arrangement. */
+	public var xOffset(get, null):Float;
+	public function get_xOffset():Float { return mXOffset; }
+	
+	/** The number of points to move the char in y direction on character arrangement. */
+	public var yOffset(get, null):Float;
+	public function get_yOffset():Float { return mYOffset; }
+	
+	/** The number of points the cursor has to be moved to the right for the next char. */
+	public var xAdvance(get, null):Float;
+	public function get_xAdvance():Float { return mXAdvance; }
+	
+	/** The width of the character in points. */
+	public var width(get, null):Float;
+	public function get_width():Float { return mWidth; }
+	
+	/** The height of the character in points. */
+	public var height(get, null):Float;
+	public function get_height():Float { return mHeight; }
+	
+	public var x(get, null):Float;
+	public function get_x():Float { return mX; }
+	
+	public var y(get, null):Float;
+	public function get_y():Float { return mY; }
+}

--- a/away3d/textfield/BitmapFont.hx
+++ b/away3d/textfield/BitmapFont.hx
@@ -1,0 +1,532 @@
+// =================================================================================================
+//
+//	Starling Framework
+//	Copyright 2011-2014 Gamua. All Rights Reserved.
+//
+//	This program is free software. You can redistribute and/or modify it
+//	in accordance with the terms of the accompanying license agreement.
+//
+// =================================================================================================
+
+package away3d.textfield;
+
+import away3d.materials.TextureMaterial;
+import js.Browser;
+import openfl.geom.Rectangle;
+import openfl.Vector;
+
+/** The BitmapFont class parses bitmap font files and arranges the glyphs
+ *  in the form of a text.
+ *
+ *  The class parses the Xml format as it is used in the 
+ *  <a href="http://www.angelcode.com/products/bmfont/">AngelCode Bitmap Font Generator</a> or
+ *  the <a href="http://glyphdesigner.71squared.com/">Glyph Designer</a>. 
+ *  This is what the file format looks like:
+ *
+ *  <pre> 
+ *  &lt;font&gt;
+ *    &lt;info face="BranchingMouse" size="40" /&gt;
+ *    &lt;common lineHeight="40" /&gt;
+ *    &lt;pages&gt;  &lt;!-- currently, only one page is supported --&gt;
+ *      &lt;page id="0" file="texture.png" /&gt;
+ *    &lt;/pages&gt;
+ *    &lt;chars&gt;
+ *      &lt;char id="32" x="60" y="29" width="1" height="1" xoffset="0" yoffset="27" xadvance="8" /&gt;
+ *      &lt;char id="33" x="155" y="144" width="9" height="21" xoffset="0" yoffset="6" xadvance="9" /&gt;
+ *    &lt;/chars&gt;
+ *    &lt;kernings&gt; &lt;!-- Kerning is optional --&gt;
+ *      &lt;kerning first="83" second="83" amount="-4"/&gt;
+ *    &lt;/kernings&gt;
+ *  &lt;/font&gt;
+ *  </pre>
+ *  
+ *  Pass an instance of this class to the method <code>registerBitmapFont</code> of the
+ *  TextField class. Then, set the <code>fontName</code> property of the text field to the 
+ *  <code>name</code> value of the bitmap font. This will make the text field use the bitmap
+ *  font.  
+ */
+
+class BitmapFont
+{
+	/** Use this constant for the <code>fontSize</code> property of the TextField class to 
+	 *  render the bitmap font in exactly the size it was created. */ 
+	public static var NATIVE_SIZE:Int = -1;
+	
+	/** The font name of the embedded minimal bitmap font. Use this e.g. for debug output. */
+	public static var MINI:String = "mini";
+	
+	private static var CHAR_SPACE:Int           = 32;
+	private static var CHAR_TAB:Int             =  9;
+	private static var CHAR_NEWLINE:Int         = 10;
+	private static var CHAR_CARRIAGE_RETURN:Int = 13;
+	
+	private var mFontMaterial:TextureMaterial;
+	private var mChars:Map<Int, BitmapChar>;
+	private var mName:String;
+	private var mSize:Float;
+	private var mLineHeight:Float;
+	private var mBaseline:Float;
+	private var mOffsetX:Float;
+	private var mOffsetY:Float;
+
+	/** Helper objects. */
+	private static var sLines = new Vector<Array<CharLocation>>(false);
+	
+	/** Creates a bitmap font by parsing an Xml file and uses the specified texture. 
+	 *  If you don't pass any data, the "mini" font will be created. */
+	public function new(texture:TextureMaterial=null, fontXml:Xml=null)
+	{
+		// if no texture is passed in, we create the minimal, embedded font
+		if (texture == null && fontXml == null)
+		{
+			texture = MiniBitmapFont.texture;
+			fontXml = MiniBitmapFont.xml;
+		}
+		
+		mName = "unknown";
+		mLineHeight = mSize = mBaseline = 14;
+		mOffsetX = mOffsetY = 0.0;
+		mFontMaterial = texture;
+		mChars = new Map<Int, BitmapChar>();
+
+		parseFontXml(fontXml);
+	}
+	
+	/** Disposes the texture of the bitmap font! */
+	public function dispose():Void
+	{
+		if (mFontMaterial != null)
+			mFontMaterial.dispose();
+	}
+	
+	private function parseFontXml(fontXml:Xml):Void
+	{
+		var frameX:Float = 0;
+        var frameY:Float = 0;
+		var scale:Float = 1;
+		
+		for (font in fontXml.elementsNamed("font")) {
+			
+			if (font.nodeType == Xml.Element ) {
+				for (info in font.elementsNamed("info")) {
+					if (info.nodeType == Xml.Element ) {
+						mName = info.get("face");
+						mSize = Std.parseFloat(info.get("size")) / scale;
+					}
+				}
+				for (common in font.elementsNamed("common")) {
+					if (common.nodeType == Xml.Element ) {
+						mLineHeight = Std.parseFloat(common.get("lineHeight")) / scale;
+						mBaseline = Std.parseFloat(common.get("base")) / scale;
+					}
+				}
+				for (chars in font.elementsNamed("chars")) {
+					if (chars.nodeType == Xml.Element ) {
+						for (char in chars.elementsNamed("char")) {
+							if (char.nodeType == Xml.Element ) {
+								
+								var id:Int = Std.parseInt(char.get("id"));
+								
+								var xOffset:Float  = Std.parseFloat(char.get("xoffset"))  / scale;
+								var yOffset:Float  = Std.parseFloat(char.get("yoffset"))  / scale;
+								var xAdvance:Float = Std.parseFloat(char.get("xadvance")) / scale;
+								
+								var region:Rectangle = new Rectangle();
+								region.x = Std.parseFloat(char.get("x")) / scale + frameX;
+								region.y = Std.parseFloat(char.get("y")) / scale + frameY;
+								region.width  = Std.parseFloat(char.get("width"))  / scale;
+								region.height = Std.parseFloat(char.get("height")) / scale;
+								
+								var bitmapChar:BitmapChar = new BitmapChar(id, region.x, region.y, region.width, region.height, xOffset, yOffset, xAdvance);
+								addChar(id, bitmapChar);
+							}
+						}
+					}
+				}
+				for (kernings in font.elementsNamed("kernings")) {
+					if (kernings.nodeType == Xml.Element ) {
+						for (kerning in kernings.elementsNamed("kerning")) {
+							if (kerning.nodeType == Xml.Element ) {
+								
+								var first:Int  = Std.parseInt(kerning.get("first"));
+								var second:Int = Std.parseInt(kerning.get("second"));
+								var amount:Float = Std.parseFloat(kerning.get("amount")) / scale;
+								if (mChars.exists(second)) {
+									getChar(second).addKerning(first, amount);
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	
+	/** Returns a single bitmap char with a certain character ID. */
+	public function getChar(charID:Int):BitmapChar
+	{
+		return mChars[charID];   
+	}
+	
+	/** Adds a bitmap char with a certain character ID. */
+	public function addChar(charID:Int, bitmapChar:BitmapChar):Void
+	{
+		mChars[charID] = bitmapChar;
+	}
+	
+	/** Returns a vector containing all the character IDs that are contained in this font. */
+	public function getCharIDs(result:Vector<Int>=null):Vector<Int>
+	{
+		if (result == null) result = new Array<Int>();
+		
+		var keys = mChars.keys();
+		for (k in keys) {
+			var key:Int = k;
+			result[result.length] = key;
+		}
+		
+		return result;
+	}
+
+	/** Checks whether a provided string can be displayed with the font. */
+	public function hasChars(text:String):Bool
+	{
+		if (text == null) return true;
+
+		var charID:Int;
+		var numChars:Int = text.length;
+
+		for (i in 0...numChars)
+		{
+			charID = text.charCodeAt(i);
+
+			if (charID != CHAR_SPACE && charID != CHAR_TAB && charID != CHAR_NEWLINE &&
+				charID != CHAR_CARRIAGE_RETURN && getChar(charID) == null)
+			{
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/** Draws text into a Geometry. */
+	public function fillBatched(data:Vector<Float>, indices:Vector<UInt>, width:Float, height:Float, text:String,
+								  fontSize:Float=-1,
+								  hAlign:String="center", vAlign:String="center",
+								  autoScale:Bool=true, 
+								  kerning:Bool = true,
+								  letterSpacing:Float=0):Void
+	{
+		var charLocations:Vector<CharLocation> = arrangeChars(width, height, text, fontSize, 
+															   hAlign, vAlign, autoScale, kerning, letterSpacing);
+		data.length = 0;
+		indices.length = 0;
+		
+		var k:Int = 0;
+		var indicesCount:Int = 0;
+		var numChars:Int = charLocations.length;
+		
+		for (i in 0...numChars)
+		{
+			indices[indicesCount++] = i*4;
+			indices[indicesCount++] = i*4+1;
+			indices[indicesCount++] = i*4+2;
+
+			indices[indicesCount++] = i*4;
+			indices[indicesCount++] = i*4+2;
+			indices[indicesCount++] = i*4+3;
+
+			var charLocation:CharLocation = charLocations[i];
+
+			var x:Float = charLocation.x;
+			var y:Float = charLocation.y;
+			var scale:Float = charLocation.scale;
+			var char:BitmapChar = charLocation.char;
+			var width:Float = char.width*scale;
+			var height:Float = char.height*scale;
+
+			var u1:Float = char.x/mFontMaterial.texture.width;
+			var u2:Float = (char.x+char.width)/mFontMaterial.texture.width;
+			var v1:Float = char.y/mFontMaterial.texture.height;
+			var v2:Float = (char.y+char.height)/mFontMaterial.texture.height;
+
+			//1
+			data[k++] = x;
+			data[k++] = 0;
+			data[k++] = y+height;
+			//n
+			data[k++] = 0;
+			data[k++] = 0;
+			data[k++] = 0;
+			//t
+			data[k++] = 0;
+			data[k++] = 0;
+			data[k++] = 0;
+			//uv
+			data[k++] = u1;
+			data[k++] = v2;
+			//seconduv
+			data[k++] = 0;
+			data[k++] = 0;
+
+			//2
+			data[k++] = x;
+			data[k++] = 0;
+			data[k++] = y;
+			//n
+			data[k++] = 0;
+			data[k++] = 0;
+			data[k++] = 0;
+			//t
+			data[k++] = 0;
+			data[k++] = 0;
+			data[k++] = 0;
+			//uv
+			data[k++] = u1;
+			data[k++] = v1;
+			//seconduv
+			data[k++] = 0;
+			data[k++] = 0;
+
+			//3
+			data[k++] = x+width;
+			data[k++] = 0;
+			data[k++] = y;
+			//n
+			data[k++] = 0;
+			data[k++] = 0;
+			data[k++] = 0;
+			//t
+			data[k++] = 0;
+			data[k++] = 0;
+			data[k++] = 0;
+			//uv
+			data[k++] = u2;
+			data[k++] = v1;
+			//seconduv
+			data[k++] = 0;
+			data[k++] = 0;
+
+			//4
+			data[k++] = x+width;
+			data[k++] = 0;
+			data[k++] = y+height;
+			//n
+			data[k++] = 0;
+			data[k++] = 0;
+			data[k++] = 0;
+			//t
+			data[k++] = 0;
+			data[k++] = 0;
+			data[k++] = 0;
+			//uv
+			data[k++] = u2;
+			data[k++] = v2;
+			//seconduv
+			data[k++] = 0;
+			data[k++] = 0;
+		}
+		
+		CharLocation.rechargePool();
+	}
+	
+	public function getMaterialClone():TextureMaterial 
+	{
+		return new TextureMaterial(mFontMaterial.texture, mFontMaterial.smooth, mFontMaterial.repeat, mFontMaterial.mipmap);
+	}
+	
+	/** Arranges the characters of a text inside a rectangle, adhering to the given settings. 
+	 *  Returns a Vector of CharLocations. */
+	private function arrangeChars(width:Float, height:Float, text:String, fontSize:Float=-1,
+								  hAlign:String="center", vAlign:String="center",
+								  autoScale:Bool=true, kerning:Bool=true, letterSpacing:Float=0):Vector<CharLocation>
+	{
+		if (hAlign == null) hAlign = HAlign.CENTER;
+		if (vAlign == null) vAlign = VAlign.CENTER;
+		
+		if (text == null || text.length == 0) return CharLocation.vectorFromPool();
+		if (fontSize < 0) fontSize *= -mSize;
+		
+		var finished:Bool = false;
+		var charLocation:CharLocation;
+		var numChars:Int;
+		var containerWidth:Float = 0;
+		var containerHeight:Float = 0;
+		var scale:Float = 1;
+		
+		var currentX:Float = 0;
+		var currentY:Float = 0;
+		
+		while (!finished)
+		{
+			sLines = new Vector<Array<CharLocation>>(false);
+			scale = fontSize / mSize;
+			containerWidth  = width / scale;
+			containerHeight = height / scale;
+			
+			if (mLineHeight <= containerHeight)
+			{
+				var lastWhiteSpace:Int = -1;
+				var lastCharID:Int = -1;
+				currentX = 0;
+				currentY = 0;
+				var currentLine:Array<CharLocation> = CharLocation.vectorFromPool();
+				
+				numChars = text.length;
+				for (i in 0...numChars) 
+				{
+					var lineFull:Bool = false;
+					var charID:Int = text.charCodeAt(i);
+					var char:BitmapChar = getChar(charID);
+					
+					if (charID == CHAR_NEWLINE || charID == CHAR_CARRIAGE_RETURN)
+					{
+						lineFull = true;
+					}
+					else if (char == null)
+					{
+						trace("[BitmapFont] Missing character: " + charID);
+					}
+					else
+					{
+						if (charID == CHAR_SPACE || charID == CHAR_TAB)
+							lastWhiteSpace = i;
+						
+						if (kerning)
+							currentX += char.getKerning(lastCharID);
+						
+						charLocation = CharLocation.instanceFromPool(char);
+						charLocation.x = currentX + char.xOffset;
+						charLocation.y = currentY + char.yOffset;
+						currentLine[currentLine.length] = charLocation; // push
+						
+						currentX += char.xAdvance;
+						lastCharID = charID;
+						
+						if (charLocation.x + char.width > containerWidth)
+						{
+							// when autoscaling, we must not split a word in half -> restart
+							if (autoScale && lastWhiteSpace == -1)
+								break;
+
+							// remove characters and add them again to next line
+							var numCharsToRemove:Int = lastWhiteSpace == -1 ? 1 : i - lastWhiteSpace;
+							var removeIndex:Int = currentLine.length - numCharsToRemove;
+							
+							currentLine.splice(removeIndex, numCharsToRemove);
+							
+							if (currentLine.length == 0)
+								break;
+							
+							//i -= numCharsToRemove;
+							lineFull = true;
+						}
+					}
+					
+					if (i == numChars - 1)
+					{
+						sLines[sLines.length] = currentLine; // push
+						finished = true;
+					}
+					else if (lineFull)
+					{
+						sLines[sLines.length] = currentLine; // push
+						if (lastWhiteSpace == i)
+							currentLine.pop();
+						
+						if (currentY + 2*mLineHeight <= containerHeight)
+						{
+							currentLine = CharLocation.vectorFromPool();
+							currentX = 0;
+							currentY += mLineHeight;
+							lastWhiteSpace = -1;
+							lastCharID = -1;
+						}
+						else
+						{
+							break;
+						}
+					}
+				} // for each char
+			} // if (mLineHeight <= containerHeight)
+			
+			if (autoScale && !finished && fontSize > 3)
+				fontSize -= 1;
+			else
+				finished = true; 
+		} // while (!finished)
+		
+		var finalLocations:Array<CharLocation> = CharLocation.vectorFromPool();
+		var numLines:Int = sLines.length;
+		var bottom:Float = currentY + mLineHeight;
+		var yOffset:Int = 0;
+		
+		if (vAlign == VAlign.BOTTOM)      yOffset =  Std.int (containerHeight - bottom);
+		else if (vAlign == VAlign.CENTER) yOffset = Std.int ((containerHeight - bottom) / 2);
+		
+		for (lineID in 0...numLines)
+		{
+			var line:Array<CharLocation> = sLines[lineID];
+			numChars = line.length;
+			
+			if (numChars == 0) continue;
+			
+			var xOffset:Int = 0;
+			var lastLocation:CharLocation = line[line.length-1];
+			var right:Float = lastLocation.x - lastLocation.char.xOffset 
+											  + lastLocation.char.xAdvance;
+			
+			if (hAlign == HAlign.RIGHT)       xOffset = Std.int (containerWidth - right);
+			else if (hAlign == HAlign.CENTER) xOffset = Std.int ((containerWidth - right) / 2);
+			
+			for (c in 0...numChars)
+			{
+				charLocation = line[c];
+				charLocation.x = scale * (charLocation.x + xOffset + mOffsetX);
+				charLocation.y = scale * (charLocation.y + yOffset + mOffsetY);
+				charLocation.scale = scale;
+				
+				if (charLocation.char.width > 0 && charLocation.char.height > 0)
+					finalLocations[finalLocations.length] = charLocation;
+			}
+		}
+		
+		return finalLocations;
+	}
+	
+	/** The name of the font as it was parsed from the font file. */
+	public var name(get, null):String;
+	public function get_name():String { return mName; }
+	
+	/** The native size of the font. */
+	public var size(get, null):Float;
+	public function get_size():Float { return mSize; }
+	
+	/** The height of one line in points. */
+	public var lineHeight(get, set):Float;
+	public function get_lineHeight():Float { return mLineHeight; }
+	public function set_lineHeight(value:Float):Float { return mLineHeight = value; }
+
+	/** The baseline of the font. This property does not affect text rendering;
+	 *  it's just an information that may be useful for exact text placement. */
+	public var baseline(get, set):Float;
+	public function get_baseline():Float { return mBaseline; }
+	public function set_baseline(value:Float):Float { return mBaseline = value; }
+	
+	/** An offset that moves any generated text along the x-axis (in points).
+	 *  Useful to make up for incorrect font data. @default 0. */ 
+	public var offsetX(get, set):Float;
+	public function get_offsetX():Float { return mOffsetX; }
+	public function set_offsetX(value:Float):Float { return mOffsetX = value; }
+	
+	/** An offset that moves any generated text along the y-axis (in points).
+	 *  Useful to make up for incorrect font data. @default 0. */
+	public var offsetY(get, set):Float;
+	public function get_offsetY():Float { return mOffsetY; }
+	public function set_offsetY(value:Float):Float { return mOffsetY = value; }
+
+	/** The underlying texture that contains all the chars. */
+	public var fontMaterial(get, null):TextureMaterial;
+	public function get_fontMaterial():TextureMaterial { return mFontMaterial; }
+}

--- a/away3d/textfield/BitmapFont.hx
+++ b/away3d/textfield/BitmapFont.hx
@@ -11,7 +11,6 @@
 package away3d.textfield;
 
 import away3d.materials.TextureMaterial;
-import js.Browser;
 import openfl.geom.Rectangle;
 import openfl.Vector;
 
@@ -70,7 +69,7 @@ class BitmapFont
 	private var mOffsetY:Float;
 
 	/** Helper objects. */
-	private static var sLines = new Vector<Array<CharLocation>>(false);
+	private static var sLines = new Vector<Array<CharLocation>>();
 	
 	/** Creates a bitmap font by parsing an Xml file and uses the specified texture. 
 	 *  If you don't pass any data, the "mini" font will be created. */
@@ -360,7 +359,8 @@ class BitmapFont
 		
 		while (!finished)
 		{
-			sLines = new Vector<Array<CharLocation>>(false);
+			sLines = new Vector<Array<CharLocation>>();
+			
 			scale = fontSize / mSize;
 			containerWidth  = width / scale;
 			containerHeight = height / scale;

--- a/away3d/textfield/CharLocation.hx
+++ b/away3d/textfield/CharLocation.hx
@@ -1,0 +1,80 @@
+package away3d.textfield;
+
+import openfl.Vector;
+
+/**
+ * ...
+ * @author P.J.Shand
+ */
+class CharLocation
+{
+	public var char:BitmapChar;
+    public var scale:Float;
+    public var x:Float;
+    public var y:Float;
+    
+    public function new(char:BitmapChar)
+    {
+        reset(char);
+    }
+
+    private function reset(char:BitmapChar):CharLocation
+    {
+        this.char = char;
+        return this;
+    }
+
+	public function getChar():BitmapChar {
+		return char;
+	}
+
+    // pooling
+
+   private static var sInstancePool = new Array<CharLocation>();
+	private static var sVectorPool = new Array<Dynamic>();
+
+	private static var sInstanceLoan = new Array<CharLocation>();
+	private static var sVectorLoan = new Array<Dynamic>();
+
+    public static function instanceFromPool(char:BitmapChar):CharLocation
+    {
+        var instance:CharLocation = sInstancePool.length > 0 ?
+			sInstancePool.pop() : new CharLocation(char);
+
+		instance.reset(char);
+		sInstanceLoan[sInstanceLoan.length] = instance;
+
+		return instance;
+    }
+
+    public static function vectorFromPool():Vector<CharLocation>
+    {
+        var vector:Vector<CharLocation> = sVectorPool.length > 0 ?
+			sVectorPool.pop() : [];
+
+		vector.length = 0;
+		sVectorLoan[sVectorLoan.length] = vector;
+
+		return vector;
+    }
+
+    public static function rechargePool():Void
+    {
+        var instance:CharLocation;
+		var vector:Vector<CharLocation>;
+
+		while (sInstanceLoan.length > 0)
+		{
+			instance = sInstanceLoan.pop();
+			instance.char = null;
+			sInstancePool[sInstancePool.length] = instance;
+		}
+
+		while (sVectorLoan.length > 0)
+		{
+			vector = sVectorLoan.pop();
+			vector.length = 0;
+			sVectorPool[sVectorPool.length] = vector;
+		}
+    }
+}

--- a/away3d/textfield/CleanMasterString.hx
+++ b/away3d/textfield/CleanMasterString.hx
@@ -1,0 +1,32 @@
+// =================================================================================================
+//
+//	Starling Framework
+//	Copyright 2014 Gamua GmbH. All Rights Reserved.
+//
+//	This program is free software. You can redistribute and/or modify it
+//	in accordance with the terms of the accompanying license agreement.
+//
+// =================================================================================================
+
+package away3d.textfield;
+
+class CleanMasterString
+{
+    /** Replaces a string's "master string" — the string it was built from —
+     *  with a single character to save memory. Find more information about this AS3 oddity
+     *  <a href="http://jacksondunstan.com/articles/2260">here</a>.
+     *
+     *  @param str String to clean
+     *  @return The input string, but with a master string only one character larger than it.
+     *  @author Jackson Dunstan, JacksonDunstan.com
+     */
+	public function new()
+	{
+		
+	}
+	
+    public function call(str:String):String
+    {
+        return ("_" + str).substr(1);
+    }
+}

--- a/away3d/textfield/HAlign.hx
+++ b/away3d/textfield/HAlign.hx
@@ -1,0 +1,35 @@
+// =================================================================================================
+//
+//	Starling Framework
+//	Copyright 2011-2014 Gamua. All Rights Reserved.
+//
+//	This program is free software. You can redistribute and/or modify it
+//	in accordance with the terms of the accompanying license agreement.
+//
+// =================================================================================================
+
+package away3d.textfield;
+
+import openfl.errors.Error;
+
+/** A class that provides constant values for horizontal alignment of objects. */
+class HAlign
+{
+	/** @private */
+	public function new() { throw new Error(); }
+	
+	/** Left alignment. */
+	public static var LEFT:String   = "left";
+	
+	/** Centered alignement. */
+	public static var CENTER:String = "center";
+	
+	/** Right alignment. */
+	public static var RIGHT:String  = "right";
+	
+	/** Indicates whether the given alignment string is valid. */
+	public static function isValid(hAlign:String):Bool
+	{
+		return hAlign == HAlign.LEFT || hAlign == HAlign.CENTER || hAlign == HAlign.RIGHT;
+	}
+}

--- a/away3d/textfield/MiniBitmapFont.hx
+++ b/away3d/textfield/MiniBitmapFont.hx
@@ -1,0 +1,299 @@
+// =================================================================================================
+//
+//	Starling Framework
+//	Copyright 2011-2014 Gamua. All Rights Reserved.
+//
+//	This program is free software. You can redistribute and/or modify it
+//	in accordance with the terms of the accompanying license agreement.
+//
+// =================================================================================================
+
+package away3d.textfield;
+
+import away3d.materials.TextureMaterial;
+import away3d.textures.BitmapTexture;
+import openfl.display.BitmapData;
+
+import openfl.display.BitmapData;
+import openfl.geom.Rectangle;
+import openfl.utils.ByteArray;
+
+/** @private
+ *  This class contains constants for the 'MINI' bitmap font. It's done that way to avoid
+ *  a dependency on the 'mx.core' library (which is required for the 'Embed' statement).
+ * 
+ *  <p>The font is based on "uni05_53.ttf" from Craig Kroeger (http://www.miniml.com) and was
+ *  converted to a Bitmap Font with "GlyphDesigner" from 71squared (http://www.71squared.com).
+ *  </p> */
+class MiniBitmapFont
+{
+	private static var BITMAP_WIDTH:Int = 128;
+	private static var BITMAP_HEIGHT:Int = 64;
+	private static var BITMAP_DATA:Array<Int> = [
+		0x78daed5d, 0xcb6edb40, 0xc0c8aa2, 0x871e8a1e, 0xfabffe34, 0xff842ffd, 0x1f0d03, 0xbee56027, 
+		0x150a0182, 0xb04bce0c, 0xb9969290, 0x80a18492, 0x578ab924, 0x872fe7e5, 0xa5a8e83f, 0x7d3b1c0e, 
+		0xcba3ca7f, 0xfb47eb6b, 0xd6b4bc06, 0x3ddf7b0f, 0x732dfb9e, 0xbdadd33b, 0xb7fcdd3a, 0x67c9fefe, 
+		0x783ce6a3, 0xca5fdfcb, 0x3aa7c8b3, 0xb5c69fdb, 0xed96b55f, 0x3ee23aad, 0x6badf7b7, 0x6896d352, 
+		0x5e0a7f0b, 0x42ffc6a2, 0xe7c9c1da, 0x93f3cf33, 0xadd788f2, 0xdf1aa4f0, 0x339f07b5, 0x650a9f79, 
+		0x8f253bf4, 0xb991eb3d, 0x9bf4f37c, 0x3ecfaf11, 0x7cc64e58, 0xfc11cf93, 0x2167cf97, 0x32f2b79e, 
+		0x9b951f2a, 0xff0cfd44, 0xf93dbb80, 0xf047eaad, 0x22ff0826, 0x40747ffd, 0x395a47c6, 0x2eb4d67d, 
+		0xd6e7f799, 0xf47f94fc, 0x113ce9fd, 0x9d110c9f, 0xcddf93ff, 0xcfe46f25, 0x7f16bf79, 0xbca2a2a2, 
+		0xfdc66f88, 0x2de8e9fa, 0x89f67d9, 0x2a261fc2, 0xaee7e52f, 0x33ee91bd, 0x1e9337f4, 0x30309b7b, 
+		0x1cb91f99, 0xb888f191, 0xd67aadfc, 0x65f63d46, 0xad17c5bf, 0x685ec08b, 0x2394fc42, 0x514c6f2c, 
+		0x1bc3c839, 0x12cf2ccf, 0xffbe5eaf, 0xf38bc197, 0xab654f2, 0x846cfc3a, 0xeaf9945c, 0x5a8f87e4, 
+		0xc43cdfc6, 0xea73561e, 0xc58aad55, 0xdeb24e14, 0xe53de399, 0x23f267f4, 0x9f951b6b, 0xbf27fe8f, 
+		0xd3e934bf, 0xb6927fcb, 0xb6a9bcbd, 0xcb5fa993, 0x295823e2, 0xff23759d, 0x2d795e4d, 0x6b6b9fa5, 
+		0xe0ffa28a, 0xfb99b802, 0x39dfaa23, 0x2136818d, 0x7d99b818, 0xd133a606, 0xcada0134, 0xfe433f73, 
+		0x358f82c8, 0x3b12a37b, 0x7cab86a0, 0xc6c3bdd8, 0x25c3f77a, 0xfb7579cd, 0x84157b78, 0x31c31ea3, 
+		0x7e3e438e, 0x5139a3b9, 0xe155b3c, 0x4bfe1e76, 0x56f27196, 0x2f8fea65, 0xc40fcc78, 0x7d642ddc, 
+		0xeb396073, 0x9f887f89, 0x60cdde9e, 0x44f6536f, 0xbde91a24, 0x8660ecff, 0x47d17f34, 0x4e55634e, 
+		0xc51e2238, 0xa85707f7, 0xe4dfb34f, 0x7b957f14, 0x6fa8bd19, 0x688f0eea, 0x5b19fbe9, 0x6138b40e, 
+		0x86e6cc11, 0xfb8fac97, 0xd1fb17c5, 0xd90afe2f, 0x2a2ada5f, 0xcdc8eb93, 0x52e3b1ac, 0x9c328211, 
+		0x3d3bcaac, 0xcbd43a94, 0xda48a427, 0x2da3af62, 0xe2fdba5c, 0x2edf8fc7, 0xe3f4427d, 0x2a8319d0, 
+		0xfe06c48f, 0xcef1756b, 0xee07dd8f, 0x564e1f8d, 0x535a6b21, 0x7218d5ab, 0x8ef86455, 0xf7bd3dc0, 
+		0xe608d7c7, 0xbff7fb9d, 0xc90fb0fa, 0xbde6f762, 0x4e6f4d04, 0xa77af241, 0xeeedadaf, 0xf4b6aab1, 
+		0x5f566d84, 0xd1713637, 0x3452ff23, 0xfa3c5aff, 0xd9789bcd, 0xa928fbdb, 0xc20c6cce, 0x92f5bdd9, 
+		0xfe1fed31, 0x1fe1ff51, 0xac36a21e, 0x50f4b5b0, 0x3fbb7732, 0xe6abacbd, 0x9cb1c747, 0xcd8da03e, 
+		0x1a5d9f8d, 0x3d143e62, 0xef51db1d, 0xc1c44c4f, 0x5a34079d, 0x918f547c, 0x73e65c5a, 0x2bd6b1f8, 
+		0x197359ea, 0xfc5f54ff, 0x47c83f2b, 0xc68af441, 0x8ef87c18, 0xfb98153b, 0x66cc5d47, 0xe2906c3d, 
+		0xcffaee96, 0xe83e63f5, 0xdc5ac7eb, 0xa918edff, 0xd9f59539, 0xc7a8bd60, 0xe31e569f, 0xd9dad668, 
+		0xff5f98bf, 0x88c9ffab, 0xfacc600c, 0x264f9185, 0x93a3bd87, 0x8a3f89fa, 0x22269fc7, 0xe47a959c, 
+		0x398395d0, 0x7c12b35f, 0xd4ef63b0, 0x7a8fd8d9, 0x744f8668, 0x7f29dbe7, 0xa5ec53f4, 0x1e91b911, 
+		0x366f88e0, 0x64063778, 0xcfef7daf, 0xc91a6fa1, 0x98c43ad7, 0xda839ead, 0x633134da, 0x73d8dbff, 
+		0x2cbe6567, 0x933f49f, 0x99475cea, 0x32d27b68, 0xf5692176, 0x7584fc55, 0xf928b9ec, 0x48de68b4, 
+		0xff57f03f, 0xabb36adc, 0xa1f866a4, 0x4616ed79, 0x44fb552b, 0x1e286271, 0x9cda1f88, 0xda39e688, 
+		0xd61691d9, 0x9c68ff65, 0x74263c7b, 0xd657994f, 0x4463bf56, 0xf4e0f47, 0x45f34b6c, 0x8cc89c5f, 
+		0xfafcdeac, 0xb797d38c, 0xce84abba, 0xe3c9d0f3, 0x5756bc13, 0xa9f1a331, 0xbb5a6f60, 0xe21756fe, 
+		0xc8cc504f, 0xfeca4c78, 0xcf0e45e4, 0xcfe015b4, 0x2e14ed1b, 0x607a6b94, 0x9931c6be, 0x7bb1c833, 
+		0x67c2959e, 0x11346657, 0x6d8782d9, 0x23f98c68, 0xbdb1a8a8, 0x281ffb5b, 0xb81ab13d, 0xacad8ac4, 
+		0xbe4bfe34, 0xabfabafa, 0x3f0419d8, 0x42a9ff79, 0xf9462f7f, 0xb965ed07, 0xc57b4abe, 0x8cb9ce8a, 
+		0x2bd6ebcd, 0xb25fee81, 0x8cb8ea2b, 0xf99d489f, 0x10a3ff68, 0x5e8ed923, 0x45f9f267, 0xf22c4545, 
+		0x45454545, 0x45454545, 0x45454545, 0x45454545, 0x45fba577, 0x2eecdb70
+	];
+	
+	private static var Xml_DATA:Xml = Xml.parse('<font>
+		<info face="mini" size="8" bold="0" italic="0" smooth="0"/>
+		<common lineHeight="8" base="7" scaleW="128" scaleH="64" pages="1" packed="0"/>
+		<chars count="191">
+			<char id="195" x="1" y="1" width="5" height="9" xoffset="0" yoffset="-2" xadvance="6"/>
+			<char id="209" x="7" y="1" width="5" height="9" xoffset="0" yoffset="-2" xadvance="6"/>
+			<char id="213" x="13" y="1" width="5" height="9" xoffset="0" yoffset="-2" xadvance="6"/>
+			<char id="253" x="19" y="1" width="4" height="9" xoffset="0" yoffset="0" xadvance="5"/>
+			<char id="255" x="24" y="1" width="4" height="9" xoffset="0" yoffset="0" xadvance="5"/>
+			<char id="192" x="29" y="1" width="5" height="8" xoffset="0" yoffset="-1" xadvance="6"/>
+			<char id="193" x="35" y="1" width="5" height="8" xoffset="0" yoffset="-1" xadvance="6"/>
+			<char id="194" x="41" y="1" width="5" height="8" xoffset="0" yoffset="-1" xadvance="6"/>
+			<char id="197" x="47" y="1" width="5" height="8" xoffset="0" yoffset="-1" xadvance="6"/>
+			<char id="200" x="53" y="1" width="5" height="8" xoffset="0" yoffset="-1" xadvance="6"/>
+			<char id="201" x="59" y="1" width="5" height="8" xoffset="0" yoffset="-1" xadvance="6"/>
+			<char id="202" x="65" y="1" width="5" height="8" xoffset="0" yoffset="-1" xadvance="6"/>
+			<char id="210" x="71" y="1" width="5" height="8" xoffset="0" yoffset="-1" xadvance="6"/>
+			<char id="211" x="77" y="1" width="5" height="8" xoffset="0" yoffset="-1" xadvance="6"/>
+			<char id="212" x="83" y="1" width="5" height="8" xoffset="0" yoffset="-1" xadvance="6"/>
+			<char id="217" x="89" y="1" width="5" height="8" xoffset="0" yoffset="-1" xadvance="6"/>
+			<char id="218" x="95" y="1" width="5" height="8" xoffset="0" yoffset="-1" xadvance="6"/>
+			<char id="219" x="101" y="1" width="5" height="8" xoffset="0" yoffset="-1" xadvance="6"/>
+			<char id="221" x="107" y="1" width="5" height="8" xoffset="0" yoffset="-1" xadvance="6"/>
+			<char id="206" x="113" y="1" width="3" height="8" xoffset="-1" yoffset="-1" xadvance="2"/>
+			<char id="204" x="117" y="1" width="2" height="8" xoffset="-1" yoffset="-1" xadvance="2"/>
+			<char id="205" x="120" y="1" width="2" height="8" xoffset="0" yoffset="-1" xadvance="2"/>
+			<char id="36"  x="1" y="11" width="5" height="7" xoffset="0" yoffset="1" xadvance="6"/>
+			<char id="196" x="7" y="11" width="5" height="7" xoffset="0" yoffset="0" xadvance="6"/>
+			<char id="199" x="13" y="11" width="5" height="7" xoffset="0" yoffset="2" xadvance="6"/>
+			<char id="203" x="19" y="11" width="5" height="7" xoffset="0" yoffset="0" xadvance="6"/>
+			<char id="214" x="25" y="11" width="5" height="7" xoffset="0" yoffset="0" xadvance="6"/>
+			<char id="220" x="31" y="11" width="5" height="7" xoffset="0" yoffset="0" xadvance="6"/>
+			<char id="224" x="37" y="11" width="4" height="7" xoffset="0" yoffset="0" xadvance="5"/>
+			<char id="225" x="42" y="11" width="4" height="7" xoffset="0" yoffset="0" xadvance="5"/>
+			<char id="226" x="47" y="11" width="4" height="7" xoffset="0" yoffset="0" xadvance="5"/>
+			<char id="227" x="52" y="11" width="4" height="7" xoffset="0" yoffset="0" xadvance="5"/>
+			<char id="232" x="57" y="11" width="4" height="7" xoffset="0" yoffset="0" xadvance="5"/>
+			<char id="233" x="62" y="11" width="4" height="7" xoffset="0" yoffset="0" xadvance="5"/>
+			<char id="234" x="67" y="11" width="4" height="7" xoffset="0" yoffset="0" xadvance="5"/>
+			<char id="235" x="72" y="11" width="4" height="7" xoffset="0" yoffset="0" xadvance="5"/>
+			<char id="241" x="77" y="11" width="4" height="7" xoffset="0" yoffset="0" xadvance="5"/>
+			<char id="242" x="82" y="11" width="4" height="7" xoffset="0" yoffset="0" xadvance="5"/>
+			<char id="243" x="87" y="11" width="4" height="7" xoffset="0" yoffset="0" xadvance="5"/>
+			<char id="244" x="92" y="11" width="4" height="7" xoffset="0" yoffset="0" xadvance="5"/>
+			<char id="245" x="97" y="11" width="4" height="7" xoffset="0" yoffset="0" xadvance="5"/>
+			<char id="249" x="102" y="11" width="4" height="7" xoffset="0" yoffset="0" xadvance="5"/>
+			<char id="250" x="107" y="11" width="4" height="7" xoffset="0" yoffset="0" xadvance="5"/>
+			<char id="251" x="112" y="11" width="4" height="7" xoffset="0" yoffset="0" xadvance="5"/>
+			<char id="254" x="117" y="11" width="4" height="7" xoffset="0" yoffset="2" xadvance="5"/>
+			<char id="123" x="122" y="11" width="3" height="7" xoffset="0" yoffset="1" xadvance="4"/>
+			<char id="125" x="1" y="19" width="3" height="7" xoffset="0" yoffset="1" xadvance="4"/>
+			<char id="167" x="5" y="19" width="3" height="7" xoffset="0" yoffset="1" xadvance="4"/>
+			<char id="207" x="9" y="19" width="3" height="7" xoffset="-1" yoffset="0" xadvance="2"/>
+			<char id="106" x="13" y="19" width="2" height="7" xoffset="0" yoffset="2" xadvance="3"/>
+			<char id="40" x="16" y="19" width="2" height="7" xoffset="0" yoffset="1" xadvance="3"/>
+			<char id="41" x="19" y="19" width="2" height="7" xoffset="0" yoffset="1" xadvance="3"/>
+			<char id="91" x="22" y="19" width="2" height="7" xoffset="0" yoffset="1" xadvance="3"/>
+			<char id="93" x="25" y="19" width="2" height="7" xoffset="0" yoffset="1" xadvance="3"/>
+			<char id="124" x="28" y="19" width="1" height="7" xoffset="1" yoffset="1" xadvance="4"/>
+			<char id="81" x="30" y="19" width="5" height="6" xoffset="0" yoffset="2" xadvance="6"/>
+			<char id="163" x="36" y="19" width="5" height="6" xoffset="0" yoffset="1" xadvance="6"/>
+			<char id="177" x="42" y="19" width="5" height="6" xoffset="0" yoffset="2" xadvance="6"/>
+			<char id="181" x="48" y="19" width="5" height="6" xoffset="0" yoffset="3" xadvance="6"/>
+			<char id="103" x="54" y="19" width="4" height="6" xoffset="0" yoffset="3" xadvance="5"/>
+			<char id="112" x="59" y="19" width="4" height="6" xoffset="0" yoffset="3" xadvance="5"/>
+			<char id="113" x="64" y="19" width="4" height="6" xoffset="0" yoffset="3" xadvance="5"/>
+			<char id="121" x="69" y="19" width="4" height="6" xoffset="0" yoffset="3" xadvance="5"/>
+			<char id="162" x="74" y="19" width="4" height="6" xoffset="0" yoffset="2" xadvance="5"/>
+			<char id="228" x="79" y="19" width="4" height="6" xoffset="0" yoffset="1" xadvance="5"/>
+			<char id="229" x="84" y="19" width="4" height="6" xoffset="0" yoffset="1" xadvance="5"/>
+			<char id="231" x="89" y="19" width="4" height="6" xoffset="0" yoffset="3" xadvance="5"/>
+			<char id="240" x="94" y="19" width="4" height="6" xoffset="0" yoffset="1" xadvance="5"/>
+			<char id="246" x="99" y="19" width="4" height="6" xoffset="0" yoffset="1" xadvance="5"/>
+			<char id="252" x="104" y="19" width="4" height="6" xoffset="0" yoffset="1" xadvance="5"/>
+			<char id="238" x="109" y="19" width="3" height="6" xoffset="-1" yoffset="1" xadvance="2"/>
+			<char id="59" x="113" y="19" width="2" height="6" xoffset="0" yoffset="3" xadvance="4"/>
+			<char id="236" x="116" y="19" width="2" height="6" xoffset="-1" yoffset="1" xadvance="2"/>
+			<char id="237" x="119" y="19" width="2" height="6" xoffset="0" yoffset="1" xadvance="2"/>
+			<char id="198" x="1" y="27" width="9" height="5" xoffset="0" yoffset="2" xadvance="10"/>
+			<char id="190" x="11" y="27" width="8" height="5" xoffset="0" yoffset="2" xadvance="9"/>
+			<char id="87" x="20" y="27" width="7" height="5" xoffset="0" yoffset="2" xadvance="8"/>
+			<char id="188" x="28" y="27" width="7" height="5" xoffset="0" yoffset="2" xadvance="8"/>
+			<char id="189" x="36" y="27" width="7" height="5" xoffset="0" yoffset="2" xadvance="8"/>
+			<char id="38" x="44" y="27" width="6" height="5" xoffset="0" yoffset="2" xadvance="7"/>
+			<char id="164" x="51" y="27" width="6" height="5" xoffset="0" yoffset="2" xadvance="7"/>
+			<char id="208" x="58" y="27" width="6" height="5" xoffset="0" yoffset="2" xadvance="7"/>
+			<char id="8364" x="65" y="27" width="6" height="5" xoffset="0" yoffset="2" xadvance="7"/>
+			<char id="65" x="72" y="27" width="5" height="5" xoffset="0" yoffset="2" xadvance="6"/>
+			<char id="66" x="78" y="27" width="5" height="5" xoffset="0" yoffset="2" xadvance="6"/>
+			<char id="67" x="84" y="27" width="5" height="5" xoffset="0" yoffset="2" xadvance="6"/>
+			<char id="68" x="90" y="27" width="5" height="5" xoffset="0" yoffset="2" xadvance="6"/>
+			<char id="69" x="96" y="27" width="5" height="5" xoffset="0" yoffset="2" xadvance="6"/>
+			<char id="70" x="102" y="27" width="5" height="5" xoffset="0" yoffset="2" xadvance="6"/>
+			<char id="71" x="108" y="27" width="5" height="5" xoffset="0" yoffset="2" xadvance="6"/>
+			<char id="72" x="114" y="27" width="5" height="5" xoffset="0" yoffset="2" xadvance="6"/>
+			<char id="75" x="120" y="27" width="5" height="5" xoffset="0" yoffset="2" xadvance="6"/>
+			<char id="77" x="1" y="33" width="5" height="5" xoffset="0" yoffset="2" xadvance="6"/>
+			<char id="78" x="7" y="33" width="5" height="5" xoffset="0" yoffset="2" xadvance="6"/>
+			<char id="79" x="13" y="33" width="5" height="5" xoffset="0" yoffset="2" xadvance="6"/>
+			<char id="80" x="19" y="33" width="5" height="5" xoffset="0" yoffset="2" xadvance="6"/>
+			<char id="82" x="25" y="33" width="5" height="5" xoffset="0" yoffset="2" xadvance="6"/>
+			<char id="83" x="31" y="33" width="5" height="5" xoffset="0" yoffset="2" xadvance="6"/>
+			<char id="84" x="37" y="33" width="5" height="5" xoffset="0" yoffset="2" xadvance="6"/>
+			<char id="85" x="43" y="33" width="5" height="5" xoffset="0" yoffset="2" xadvance="6"/>
+			<char id="86" x="49" y="33" width="5" height="5" xoffset="0" yoffset="2" xadvance="6"/>
+			<char id="88" x="55" y="33" width="5" height="5" xoffset="0" yoffset="2" xadvance="6"/>
+			<char id="89" x="61" y="33" width="5" height="5" xoffset="0" yoffset="2" xadvance="6"/>
+			<char id="90" x="67" y="33" width="5" height="5" xoffset="0" yoffset="2" xadvance="6"/>
+			<char id="50" x="73" y="33" width="5" height="5" xoffset="0" yoffset="2" xadvance="6"/>
+			<char id="51" x="79" y="33" width="5" height="5" xoffset="0" yoffset="2" xadvance="6"/>
+			<char id="52" x="85" y="33" width="5" height="5" xoffset="0" yoffset="2" xadvance="6"/>
+			<char id="53" x="91" y="33" width="5" height="5" xoffset="0" yoffset="2" xadvance="6"/>
+			<char id="54" x="97" y="33" width="5" height="5" xoffset="0" yoffset="2" xadvance="6"/>
+			<char id="56" x="103" y="33" width="5" height="5" xoffset="0" yoffset="2" xadvance="6"/>
+			<char id="57" x="109" y="33" width="5" height="5" xoffset="0" yoffset="2" xadvance="6"/>
+			<char id="48" x="115" y="33" width="5" height="5" xoffset="0" yoffset="2" xadvance="6"/>
+			<char id="47" x="121" y="33" width="5" height="5" xoffset="0" yoffset="2" xadvance="6"/>
+			<char id="64" x="1" y="39" width="5" height="5" xoffset="0" yoffset="2" xadvance="6"/>
+			<char id="92" x="7" y="39" width="5" height="5" xoffset="0" yoffset="2" xadvance="6"/>
+			<char id="37" x="13" y="39" width="5" height="5" xoffset="0" yoffset="2" xadvance="6"/>
+			<char id="43" x="19" y="39" width="5" height="5" xoffset="0" yoffset="2" xadvance="6"/>
+			<char id="35" x="25" y="39" width="5" height="5" xoffset="0" yoffset="2" xadvance="6"/>
+			<char id="42" x="31" y="39" width="5" height="5" xoffset="0" yoffset="2" xadvance="6"/>
+			<char id="165" x="37" y="39" width="5" height="5" xoffset="0" yoffset="2" xadvance="6"/>
+			<char id="169" x="43" y="39" width="5" height="5" xoffset="0" yoffset="2" xadvance="6"/>
+			<char id="174" x="49" y="39" width="5" height="5" xoffset="0" yoffset="2" xadvance="6"/>
+			<char id="182" x="55" y="39" width="5" height="5" xoffset="0" yoffset="2" xadvance="6"/>
+			<char id="216" x="61" y="39" width="5" height="5" xoffset="0" yoffset="2" xadvance="6"/>
+			<char id="247" x="67" y="39" width="5" height="5" xoffset="0" yoffset="2" xadvance="6"/>
+			<char id="74" x="73" y="39" width="4" height="5" xoffset="0" yoffset="2" xadvance="5"/>
+			<char id="76" x="78" y="39" width="4" height="5" xoffset="0" yoffset="2" xadvance="5"/>
+			<char id="98" x="83" y="39" width="4" height="5" xoffset="0" yoffset="2" xadvance="5"/>
+			<char id="100" x="88" y="39" width="4" height="5" xoffset="0" yoffset="2" xadvance="5"/>
+			<char id="104" x="93" y="39" width="4" height="5" xoffset="0" yoffset="2" xadvance="5"/>
+			<char id="107" x="98" y="39" width="4" height="5" xoffset="0" yoffset="2" xadvance="5"/>
+			<char id="55" x="103" y="39" width="4" height="5" xoffset="0" yoffset="2" xadvance="5"/>
+			<char id="63" x="108" y="39" width="4" height="5" xoffset="0" yoffset="2" xadvance="5"/>
+			<char id="191" x="113" y="39" width="4" height="5" xoffset="0" yoffset="2" xadvance="5"/>
+			<char id="222" x="118" y="39" width="4" height="5" xoffset="0" yoffset="2" xadvance="5"/>
+			<char id="223" x="123" y="39" width="4" height="5" xoffset="0" yoffset="2" xadvance="5"/>
+			<char id="116" x="1" y="45" width="3" height="5" xoffset="0" yoffset="2" xadvance="4"/>
+			<char id="60" x="5" y="45" width="3" height="5" xoffset="0" yoffset="2" xadvance="4"/>
+			<char id="62" x="9" y="45" width="3" height="5" xoffset="0" yoffset="2" xadvance="4"/>
+			<char id="170" x="13" y="45" width="3" height="5" xoffset="0" yoffset="2" xadvance="4"/>
+			<char id="186" x="17" y="45" width="3" height="5" xoffset="0" yoffset="2" xadvance="4"/>
+			<char id="239" x="21" y="45" width="3" height="5" xoffset="-1" yoffset="2" xadvance="2"/>
+			<char id="102" x="25" y="45" width="2" height="5" xoffset="0" yoffset="2" xadvance="3"/>
+			<char id="49" x="28" y="45" width="2" height="5" xoffset="0" yoffset="2" xadvance="3"/>
+			<char id="73" x="31" y="45" width="1" height="5" xoffset="0" yoffset="2" xadvance="2"/>
+			<char id="105" x="33" y="45" width="1" height="5" xoffset="0" yoffset="2" xadvance="2"/>
+			<char id="108" x="35" y="45" width="1" height="5" xoffset="0" yoffset="2" xadvance="2"/>
+			<char id="33" x="37" y="45" width="1" height="5" xoffset="1" yoffset="2" xadvance="3"/>
+			<char id="161" x="39" y="45" width="1" height="5" xoffset="0" yoffset="2" xadvance="3"/>
+			<char id="166" x="41" y="45" width="1" height="5" xoffset="0" yoffset="2" xadvance="2"/>
+			<char id="109" x="43" y="45" width="7" height="4" xoffset="0" yoffset="3" xadvance="8"/>
+			<char id="119" x="51" y="45" width="7" height="4" xoffset="0" yoffset="3" xadvance="8"/>
+			<char id="230" x="59" y="45" width="7" height="4" xoffset="0" yoffset="3" xadvance="8"/>
+			<char id="97" x="67" y="45" width="4" height="4" xoffset="0" yoffset="3" xadvance="5"/>
+			<char id="99" x="72" y="45" width="4" height="4" xoffset="0" yoffset="3" xadvance="5"/>
+			<char id="101" x="77" y="45" width="4" height="4" xoffset="0" yoffset="3" xadvance="5"/>
+			<char id="110" x="82" y="45" width="4" height="4" xoffset="0" yoffset="3" xadvance="5"/>
+			<char id="111" x="87" y="45" width="4" height="4" xoffset="0" yoffset="3" xadvance="5"/>
+			<char id="115" x="92" y="45" width="4" height="4" xoffset="0" yoffset="3" xadvance="5"/>
+			<char id="117" x="97" y="45" width="4" height="4" xoffset="0" yoffset="3" xadvance="5"/>
+			<char id="118" x="102" y="45" width="4" height="4" xoffset="0" yoffset="3" xadvance="5"/>
+			<char id="120" x="107" y="45" width="4" height="4" xoffset="0" yoffset="3" xadvance="5"/>
+			<char id="122" x="112" y="45" width="4" height="4" xoffset="0" yoffset="3" xadvance="5"/>
+			<char id="215" x="117" y="45" width="4" height="4" xoffset="0" yoffset="3" xadvance="5"/>
+			<char id="248" x="122" y="45" width="4" height="4" xoffset="0" yoffset="3" xadvance="5"/>
+			<char id="114" x="1" y="51" width="3" height="4" xoffset="0" yoffset="3" xadvance="4"/>
+			<char id="178" x="5" y="51" width="3" height="4" xoffset="0" yoffset="2" xadvance="4"/>
+			<char id="179" x="9" y="51" width="3" height="4" xoffset="0" yoffset="2" xadvance="4"/>
+			<char id="185" x="13" y="51" width="1" height="4" xoffset="0" yoffset="2" xadvance="2"/>
+			<char id="61" x="15" y="51" width="5" height="3" xoffset="0" yoffset="3" xadvance="6"/>
+			<char id="171" x="21" y="51" width="5" height="3" xoffset="0" yoffset="3" xadvance="6"/>
+			<char id="172" x="27" y="51" width="5" height="3" xoffset="0" yoffset="4" xadvance="6"/>
+			<char id="187" x="33" y="51" width="5" height="3" xoffset="0" yoffset="3" xadvance="6"/>
+			<char id="176" x="39" y="51" width="3" height="3" xoffset="0" yoffset="2" xadvance="4"/>
+			<char id="44" x="43" y="51" width="2" height="3" xoffset="0" yoffset="6" xadvance="3"/>
+			<char id="58" x="46" y="51" width="1" height="3" xoffset="1" yoffset="3" xadvance="4"/>
+			<char id="94" x="48" y="51" width="4" height="2" xoffset="-1" yoffset="2" xadvance="4"/>
+			<char id="126" x="53" y="51" width="4" height="2" xoffset="0" yoffset="3" xadvance="5"/>
+			<char id="34" x="58" y="51" width="3" height="2" xoffset="0" yoffset="2" xadvance="4"/>
+			<char id="96" x="62" y="51" width="2" height="2" xoffset="0" yoffset="2" xadvance="3"/>
+			<char id="180" x="65" y="51" width="2" height="2" xoffset="0" yoffset="2" xadvance="3"/>
+			<char id="184" x="68" y="51" width="2" height="2" xoffset="0" yoffset="7" xadvance="3"/>
+			<char id="39" x="71" y="51" width="1" height="2" xoffset="0" yoffset="2" xadvance="2"/>
+			<char id="95" x="73" y="51" width="5" height="1" xoffset="0" yoffset="7" xadvance="6"/>
+			<char id="45" x="79" y="51" width="4" height="1" xoffset="0" yoffset="4" xadvance="5"/>
+			<char id="173" x="84" y="51" width="4" height="1" xoffset="0" yoffset="4" xadvance="5"/>
+			<char id="168" x="89" y="51" width="3" height="1" xoffset="1" yoffset="2" xadvance="5"/>
+			<char id="175" x="93" y="51" width="3" height="1" xoffset="0" yoffset="2" xadvance="4"/>
+			<char id="46" x="97" y="51" width="1" height="1" xoffset="0" yoffset="6" xadvance="2"/>
+			<char id="183" x="99" y="51" width="1" height="1" xoffset="0" yoffset="4" xadvance="2"/>
+			<char id="32" x="6" y="56" width="0" height="0" xoffset="0" yoffset="127" xadvance="3"/>
+		</chars>
+	</font>');
+	
+	public static var texture(get, null):TextureMaterial;
+	public static var xml(get, null):Xml;
+	
+	public static function get_texture():TextureMaterial
+	{
+		var bitmapData:BitmapData = getBitmapData();
+		var texture:TextureMaterial = new TextureMaterial(new BitmapTexture(bitmapData));
+		bitmapData.dispose();
+		bitmapData = null;
+		return texture;
+	}
+
+	public static function getBitmapData():BitmapData
+	{
+		var bmpData:BitmapData = new BitmapData(BITMAP_WIDTH, BITMAP_HEIGHT, true, 0xFFFF0000);
+		var bmpBytes:ByteArray = new ByteArray();
+		var numBytes:Int = MiniBitmapFont.BITMAP_DATA.length;
+		for (i in 0...numBytes)
+			bmpBytes.writeUnsignedInt(MiniBitmapFont.BITMAP_DATA[i]);
+		
+		bmpBytes.uncompress();
+		bmpData.setPixels(new Rectangle(0, 0, BITMAP_WIDTH, BITMAP_HEIGHT), bmpBytes);
+		bmpBytes.clear();
+		return bmpData;
+	}
+	
+	public static function get_xml():Xml { return MiniBitmapFont.Xml_DATA; }
+}

--- a/away3d/textfield/RectangleBitmapTexture.hx
+++ b/away3d/textfield/RectangleBitmapTexture.hx
@@ -1,0 +1,40 @@
+package away3d.textfield;
+
+import away3d.textures.Texture2DBase;
+import openfl.display.BitmapData;
+import openfl.display3D.Context3D;
+import openfl.display3D.Context3DTextureFormat;
+import openfl.display3D.textures.RectangleTexture;
+import openfl.display3D.textures.TextureBase;
+
+class RectangleBitmapTexture extends Texture2DBase {
+	private var _bitmapData:BitmapData;
+
+	public function new(bitmapData:BitmapData) {
+		this.bitmapData = bitmapData;
+	}
+	
+	public var bitmapData(get_assetFullPath, set):BitmapData
+	public function get_bitmapData():BitmapData {
+		return _bitmapData;
+	}
+
+	public function set_bitmapData(value:BitmapData):BitmapData {
+		if (value == _bitmapData)
+			return value;
+
+		invalidateContent();
+		setSize(value.width, value.height);
+
+		_bitmapData = value;
+		return value;
+	}
+	
+	override private function uploadContent(texture:TextureBase):Void {
+		cast(texture, RectangleTexture).uploadFromBitmapData(_bitmapData);
+	}
+	
+	override private function createTexture(context:Context3D):TextureBase {
+		return context.createRectangleTexture(_width, _height, Context3DTextureFormat.BGRA_PACKED, false);
+	}
+}

--- a/away3d/textfield/TextField.hx
+++ b/away3d/textfield/TextField.hx
@@ -1,0 +1,262 @@
+package away3d.textfield;
+
+import away3d.core.base.CompactSubGeometry;
+import away3d.core.base.Geometry;
+import away3d.entities.Mesh;
+import away3d.materials.methods.ColorTransformMethod;
+import away3d.materials.SinglePassMaterialBase;
+import away3d.materials.TextureMaterial;
+import openfl.display.DisplayObjectContainer;
+import openfl.geom.ColorTransform;
+import openfl.geom.Rectangle;
+import openfl.text.TextFieldAutoSize;
+import openfl.Vector;
+
+
+class TextField extends Mesh {
+	
+	private var vertexData:Vector<Float> = new Vector<Float>();
+	private var indexData:Vector<UInt> = new Vector<UInt>();
+	private var mText:String = "";
+	private var mBitmapFont:BitmapFont;
+	private var mFontSize:Float;
+	private var mColor:UInt;
+	private var mHAlign:String;
+	private var mVAlign:String;
+	private var mBold:Bool;
+	private var mItalic:Bool;
+	private var mUnderline:Bool;
+	private var mAutoScale:Bool;
+	private var mAutoSize:TextFieldAutoSize;
+	private var mKerning:Bool;
+	private var mLetterSpacing:Float = 0;
+	private var mBorder:DisplayObjectContainer;
+	public var mWidth:Float;
+	public var mHeight:Float;
+	
+	public var disposeMaterial:Bool = true;
+	
+	private var _boundsRect:Rectangle = new Rectangle();
+	
+	private var _textHeight:Float;
+	private var _textWidth:Float;
+	
+	private var _subGeometry:CompactSubGeometry;
+	private var colorTransformMethod:ColorTransformMethod;
+	private var textureMaterial:TextureMaterial;
+	
+	public function new(width:Float, height:Float, text:String, bitmapFont:BitmapFont, fontSize:Float = 12, color:UInt = 0x0, bold:Bool = false, _hAlign:String="left") {
+		super(new Geometry(), bitmapFont.fontMaterial);
+		
+		mText = text;
+		mBitmapFont = bitmapFont;
+		
+		mWidth = width;
+		mHeight = height;
+		mFontSize = fontSize;
+		mColor = color;
+		mHAlign = _hAlign;
+		mVAlign = VAlign.TOP;
+		mBorder = null;
+		mKerning = true;
+		mBold = bold;
+		mAutoSize = TextFieldAutoSize.NONE;
+		_subGeometry = new CompactSubGeometry();
+		_subGeometry.autoDeriveVertexNormals = true;
+		_subGeometry.autoDeriveVertexTangents = true;
+		geometry.addSubGeometry(_subGeometry);
+		
+		textureMaterial = bitmapFont.fontMaterial;
+		var rgb:Array<UInt> = HexToRGB(color);
+		if (textureMaterial.colorTransform == null) {
+			textureMaterial.colorTransform = new ColorTransform();
+		}
+		textureMaterial.colorTransform.redMultiplier = rgb[0] / 255;
+		textureMaterial.colorTransform.greenMultiplier = rgb[1] / 255;
+		textureMaterial.colorTransform.blueMultiplier = rgb[2] / 255;
+		textureMaterial.colorTransform.alphaMultiplier = textureMaterial.alpha;
+		
+		material = textureMaterial;
+		
+		material.alphaPremultiplied = true;
+		var castMat:SinglePassMaterialBase = cast(material, SinglePassMaterialBase);
+		if (castMat != null) {
+			castMat.alphaBlending = true;
+		}
+		
+		updateText();
+	}
+	
+	public function HexToRGB(hex:UInt):Vector<UInt>
+	{
+		var rgb = new Vector<UInt>(false);
+		var r:UInt = hex >> 16 & 0xFF;
+		var g:UInt = hex >> 8 & 0xFF;
+		var b:UInt = hex & 0xFF;
+		rgb.push(r);
+		rgb.push(g);
+		rgb.push(b);
+		return rgb;
+	}
+
+	override public function dispose():Void {
+		if(disposeMaterial)material.dispose();
+		super.dispose();
+	}
+
+	private function updateText():Void {
+		
+		mBitmapFont.fillBatched(vertexData, indexData, mWidth, mHeight, mText, mFontSize, mHAlign, mVAlign, mAutoScale, mKerning, mLetterSpacing);
+		
+		_subGeometry.updateData(vertexData);
+		_subGeometry.updateIndexData(indexData);
+	}
+
+
+	/** Indicates whether the text is bold. @default false */
+	public var bold(get, set):Bool;
+	public function get_bold():Bool {
+		return mBold;
+	}
+
+	public function set_bold(value:Bool):Bool {
+		if (mBold != value) {
+			mBold = value;
+			updateText();
+		}
+		return value;
+	}
+
+	/** Indicates whether the text is italicized. @default false */
+	public var italic(get, set):Bool;
+	public function get_italic():Bool {
+		return mItalic;
+	}
+
+	public function set_italic(value:Bool):Bool {
+		if (mItalic != value) {
+			mItalic = value;
+			updateText();
+		}
+		return value;
+	}
+
+	/** Indicates whether the text is underlined. @default false */
+	public var underline(get, set):Bool;
+	public function get_underline():Bool {
+		return mUnderline;
+	}
+
+	public function set_underline(value:Bool):Bool {
+		if (mUnderline != value) {
+			mUnderline = value;
+			updateText();
+		}
+		return value;
+	}
+
+	/** Indicates whether kerning is enabled. @default true */
+	public var kerning(get, set):Bool;
+	public function get_kerning():Bool {
+		return mKerning;
+	}
+
+	public function set_kerning(value:Bool):Bool {
+		if (mKerning != value) {
+			mKerning = value;
+			updateText();
+		}
+		return value;
+	}
+
+
+	/** A number representing the amount of space that is uniformly distributed between all characters.
+	 * The value specifies the number of pixels that are added to the advance after each character.
+	 * The default value is null, which means that 0 pixels of letter spacing is used.
+	 * You can use decimal values such as 1.75. @default 0 */
+	public var letterSpacing(get, set):Float;
+	public function get_letterSpacing():Float {
+		return mLetterSpacing;
+	}
+
+	public function set_letterSpacing(value:Float):Float {
+		if (mLetterSpacing != value) {
+			mLetterSpacing = value;
+			updateText();
+		}
+		return value;
+	}
+
+	/** Indicates whether the font size is scaled down so that the complete text fits
+	 *  into the text field. @default false */
+	public var autoScale(get, set):Bool;
+	public function get_autoScale():Bool {
+		return mAutoScale;
+	}
+
+	public function set_autoScale(value:Bool):Bool {
+		if (mAutoScale != value) {
+			mAutoScale = value;
+			updateText();
+		}
+		return value;
+	}
+
+	/** Specifies the type of auto-sizing the TextField will do.
+	 *  Note that any auto-sizing will make auto-scaling useless. Furthermore, it has
+	 *  implications on alignment: horizontally auto-sized text will always be left-,
+	 *  vertically auto-sized text will always be top-aligned. @default "none" */
+	public var autoSize(get, set):TextFieldAutoSize;
+	public function get_autoSize():TextFieldAutoSize {
+		return mAutoSize;
+	}
+
+	public function set_autoSize(value:TextFieldAutoSize):TextFieldAutoSize {
+		if (mAutoSize != value) {
+			mAutoSize = value;
+			updateText();
+		}
+		return value;
+	}
+	
+	public var textHeight(get, null):Float;
+	public function get_textHeight():Float 
+	{
+		_textHeight = Math.abs(bounds.min.z - bounds.max.z);
+		return _textHeight;
+	}
+	
+	public var textWidth(get, null):Float;
+	public function get_textWidth():Float 
+	{
+		_textWidth = Math.abs(bounds.min.x - bounds.max.x);
+		return _textWidth;
+	}
+	
+	public var boundsRect(get, null):Rectangle;
+	public function get_boundsRect():Rectangle 
+	{
+		var minX:Float = bounds.min.x;
+		var maxX:Float = bounds.max.x;
+		
+		var minY:Float = bounds.min.y;
+		var maxY:Float = bounds.max.y;
+		
+		var minZ:Float = bounds.min.z;
+		var maxZ:Float = bounds.max.z;
+		
+		_boundsRect.setTo(minX, minZ, maxX - minX, maxZ - minZ);
+		return _boundsRect;
+	}
+	
+	public var alpha(get, set):Float;
+	public function get_alpha():Float 
+	{
+		return textureMaterial.colorTransform.alphaMultiplier;
+	}
+	
+	public function set_alpha(value:Float):Float 
+	{
+		return textureMaterial.colorTransform.alphaMultiplier = value;
+	}	
+}

--- a/away3d/textfield/TextField.hx
+++ b/away3d/textfield/TextField.hx
@@ -89,7 +89,7 @@ class TextField extends Mesh {
 	
 	public function HexToRGB(hex:UInt):Vector<UInt>
 	{
-		var rgb = new Vector<UInt>(false);
+		var rgb = new Vector<UInt>();
 		var r:UInt = hex >> 16 & 0xFF;
 		var g:UInt = hex >> 8 & 0xFF;
 		var b:UInt = hex & 0xFF;

--- a/away3d/textfield/VAlign.hx
+++ b/away3d/textfield/VAlign.hx
@@ -1,0 +1,35 @@
+// =================================================================================================
+//
+//	Starling Framework
+//	Copyright 2011-2014 Gamua. All Rights Reserved.
+//
+//	This program is free software. You can redistribute and/or modify it
+//	in accordance with the terms of the accompanying license agreement.
+//
+// =================================================================================================
+
+package away3d.textfield;
+
+import openfl.errors.Error;
+
+/** A class that provides constant values for vertical alignment of objects. */
+class VAlign
+{
+	/** @private */
+	public function new() { throw new Error(); }
+	
+	/** Top alignment. */
+	public static var TOP:String = "top";
+	
+	/** Centered alignment. */
+	public static var CENTER:String = "center";
+	
+	/** Bottom alignment. */
+	public static var BOTTOM:String = "bottom";
+	
+	/** Indicates whether the given alignment string is valid. */
+	public static function isValid(vAlign:String):Bool
+	{
+		return vAlign == VAlign.TOP || vAlign == VAlign.CENTER || vAlign == VAlign.BOTTOM;
+	}
+}

--- a/away3d/textfield/utils/AwayFont.hx
+++ b/away3d/textfield/utils/AwayFont.hx
@@ -1,0 +1,115 @@
+package away3d.textfield.utils;
+
+import away3d.materials.TextureMaterial;
+import away3d.textures.BitmapTexture;
+import openfl.Assets;
+import openfl.display.BitmapData;
+import openfl.errors.Error;
+import openfl.utils.ByteArray;
+/**
+ * ...
+ * @author P.J.Shand
+ * @author Thomas Byrne
+ */
+class AwayFont 
+{
+	private static var registeredBitmapFont = new Map<String, BitmapFont>();
+	private static var registeredTexture = new Map<String, BitmapTexture>();
+	private static var registeredData = new Map<String, Xml>();
+	
+	public function new()
+	{
+		
+	}
+	
+	/**
+	 * 
+	 * @param	type
+	 * @param	cacheMaterial - When true performance will improve but text using the same font will all use the samer material.
+	 * meaning that color transforms will affect all of them.
+	 * @return
+	 */
+	static public function type(type:Class<FontSize>, cacheMaterial:Bool=false):BitmapFont 
+	{
+		//try {
+			
+			var family:String = Reflect.getProperty(type, "FAMILY");
+			var size:Int = Reflect.getProperty(type, "SIZE");
+			var regName:String = family + "_" + size;
+			
+			var cached:BitmapFont = registeredBitmapFont[regName];
+			
+			//var lookup:Map<String, Dynamic> = (cacheMaterial ? registeredBitmapFont : registeredTexture);
+			if (cacheMaterial == true && cached != null) {
+				return cached;
+			}
+			
+			//var cached:Dynamic = lookup[regName];
+			if (cached == null) {
+				var xmlLocation:String = Reflect.getProperty(type, "DATA");
+				var xmlStr:String = Assets.getText(xmlLocation);
+				var data:Xml = Xml.parse(xmlStr);
+				var bmdLocation:String = Reflect.getProperty(type, "TEXTURE");
+				var texture:BitmapData = Assets.getBitmapData(bmdLocation);
+				
+				return generate(family, size, data, texture, cacheMaterial);
+				
+			/*}else if (cacheMaterial) {
+				return cached;
+				*/
+			}else {
+				var fontMaterial:TextureMaterial = new TextureMaterial(registeredTexture[regName], true, false, true);
+				fontMaterial.smooth = true;
+				fontMaterial.alphaBlending = true;
+				fontMaterial.bothSides = true;
+				
+				return new BitmapFont(fontMaterial, registeredData[regName]);
+			}
+		/*}catch (e:Error) {
+			throw new Error("Class inheriting from FontSize ("+type+") should have PUBLIC static members FAMILY, SIZE, DATA and TEXTURE.");
+		}*/
+		return null;
+		//return gen(new type()); // This approach was horribly inefficient
+	}
+	
+	public static function gen(fontSize:FontSize, cacheMaterial:Bool=false):BitmapFont {
+		return generate(fontSize.family, fontSize.size, fontSize.data, fontSize.texture, cacheMaterial);
+	}
+	
+	public static function generate(family:String, size:Int, data:Xml, texture:BitmapData, cacheMaterial:Bool=false):BitmapFont {
+		var regName:String = family + "_" + size;
+		var bmTexture:BitmapTexture;
+		var fontMaterial:TextureMaterial;
+		
+		if(cacheMaterial){
+			var bitmapFont:BitmapFont = registeredBitmapFont[regName];
+			if (bitmapFont == null) {
+				
+				bmTexture = new BitmapTexture(texture);
+				
+				fontMaterial = new TextureMaterial(bmTexture, true, false, true);
+				fontMaterial.smooth = true;
+				fontMaterial.alphaBlending = true;
+				fontMaterial.bothSides = true;
+				
+				bitmapFont = new BitmapFont(fontMaterial, data);
+				registeredBitmapFont[regName] = bitmapFont;
+			}
+			return bitmapFont;
+		}else {
+			bmTexture = registeredTexture[regName];
+			if (bmTexture == null) {
+				
+				bmTexture = new BitmapTexture(texture);
+				registeredTexture[regName] = bmTexture;
+				registeredData[regName] = data;
+			}
+			fontMaterial = new TextureMaterial(bmTexture, true, false, true);
+			fontMaterial.smooth = true;
+			fontMaterial.alphaBlending = true;
+			fontMaterial.bothSides = true;
+			
+			return new BitmapFont(fontMaterial, registeredData[regName]);
+		}
+	}	
+}

--- a/away3d/textfield/utils/FontContainer.hx
+++ b/away3d/textfield/utils/FontContainer.hx
@@ -1,0 +1,40 @@
+package away3d.textfield.utils;
+
+import openfl.Vector;
+
+/**
+ * ...
+ * @author P.J.Shand
+ * @author Thomas Byrne
+ */
+class FontContainer 
+{
+	private var fontSizes:Vector<FontSize> = new Vector<FontSize>();
+	
+	public function FontContainer() 
+	{
+		
+	}
+	
+	private function addSize(fontSize:FontSize):FontSize 
+	{
+		fontSizes.push(fontSize);
+		return fontSize;
+	}
+	
+	public function best(size:Int):FontSize 
+	{
+		var best:FontSize;
+		var lowestDif:Float = Math.POSITIVE_INFINITY;
+		for (var i:int = 0; i < fontSizes.length; i++) 
+		{
+			var fontSize:FontSize = fontSizes[i];
+			var dif:int = Math.abs(fontSize.size - size);
+			if (dif < lowestDif) {
+				best = fontSize;
+				lowestDif = dif;
+			}
+		}
+		return best;
+	}	
+}

--- a/away3d/textfield/utils/FontSize.hx
+++ b/away3d/textfield/utils/FontSize.hx
@@ -1,0 +1,36 @@
+package away3d.textfield.utils;
+
+import flash.display.Bitmap;
+import flash.display.BitmapData;
+import openfl.errors.Error;
+/**
+ * ...
+ * @author P.J.Shand
+ * @author Thomas Byrne
+ */
+class FontSize 
+{
+	public var family:String;
+	public var size:Int;
+	public var data:Xml;
+	public var texture:BitmapData;
+	
+	public function FontSize(searchClass:Bool=true) 
+	{
+		if (searchClass) {
+			var type:Class<FontSize> = Type.getClass(this);
+			try {
+				family = Reflect.getProperty(type, "FAMILY");
+				size = Reflect.getProperty(type, "SIZE");
+				
+				var dataType:Class<Dynamic> = Reflect.getProperty(type, "DATA");
+				var textureType:Class<Dynamic> = Reflect.getProperty(type, "TEXTURE");
+				data = cast(Type.createInstance(dataType, null), Xml);
+				texture = cast(Type.createInstance(textureType, null), Bitmap).bitmapData;
+				
+			}catch (e:Error) {
+				throw new Error("Class inheriting from FontSize ("+type+") should have PUBLIC static members FAMILY, SIZE, DATA and TEXTURE.");
+			}
+		}
+	}	
+}

--- a/haxelib.json
+++ b/haxelib.json
@@ -4,9 +4,9 @@
 	"license": "MIT",
 	"tags": [ "away3d", "3d", "engine", "openfl", "cross", "cpp", "flash", "game", "js", "web", "ios", "android" ],
 	"description": "Away3D is an open source, real time 3D engine for the Flash Platform and has been ported to OpenFL 2.x/Haxe",
-	"version": "1.1.0",
-	"releasenote": "Reworked to utilise the migrated Stage3D in the core OpenFL library and compatibility updates. Includes minor bug fixes.",
-	"contributors": [ "Greg209" ],
+	"version": "1.1.1",
+	"releasenote": "BitmapFont Textfield support added",
+	"contributors": [ "Greg209", "p.j.shand" ],
 	"dependencies": {
 		"openfl": ""
 	}


### PR DESCRIPTION
* BitmapFont Textfield support has been added.
* A separate pull request has been made to away3d-examples-openfl which adds a bitmapFont textfield example.
* I've also updated the contributors node in the haxelib.json ("contributors": [ "Greg209", "p.j.shand" ]) so I can also push updates to haxelib, however you're welcome to remove this change if you'd rather retain control over this.
