### PR TITLE
typo _listenToRotationChanged

### DIFF
--- a/away3d/core/base/Object3D.hx
+++ b/away3d/core/base/Object3D.hx
@@ -142,7 +142,7 @@ class Object3D extends NamedAssetBase {
             case Object3DEvent.ROTATION_CHANGED:
                 _listenToRotationChanged = true;
             case Object3DEvent.SCALE_CHANGED:
-                _listenToRotationChanged = true;
+                _listenToScaleChanged = true;
         }
     }
 


### PR DESCRIPTION
fixed typo `_listenToRotationChanged` to `_listenToScaleChanged` when `Object3DEvent.SCALE_CHANGED`