### PR TITLE
Delaunay mesh super

### DIFF
--- a/away3d/extrusions/DelaunayMesh.hx
+++ b/away3d/extrusions/DelaunayMesh.hx
@@ -74,12 +74,12 @@ class DelaunayMesh extends Mesh {
         var geom:Geometry = new Geometry();
         _subGeometry = new SubGeometry();
         geom.addSubGeometry(_subGeometry);
-        super(geom, material);
         _vectors = vectors;
         _centerMesh = centerMesh;
         _plane = plane;
         _flip = flip;
         _smoothSurface = smoothSurface;
+        super(geom, material);
     }
 
     /**

--- a/away3d/primitives/PrimitiveBase.hx
+++ b/away3d/primitives/PrimitiveBase.hx
@@ -18,7 +18,6 @@ class PrimitiveBase extends Geometry {
     private var _subGeometry:CompactSubGeometry;
     /**
 	 * Creates a new PrimitiveBase object.
-	 * @param material The material with which to render the object
 	 */
     public function new() {
         super();


### PR DESCRIPTION
`DelaunayMesh`'s constructor call to super is moved down so that more properties are set. That prevent some null reference errors.